### PR TITLE
feat(homepage): replace hardcoded stars with live GitHub star count

### DIFF
--- a/src/pages/HomepageHeader.tsx
+++ b/src/pages/HomepageHeader.tsx
@@ -2,11 +2,65 @@ import Link from '@docusaurus/Link';
 import React, {useState, useEffect} from 'react';
 import styles from './index.module.css';
 
+const GITHUB_REPO_API = 'https://api.github.com/repos/grimmory-tools/grimmory';
+const STARS_FALLBACK_LABEL = 'Star on GitHub';
+
+function formatStarsLabel(starCount: number): string {
+  const formattedCount = new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(starCount);
+
+  return `${formattedCount}+ Stars`;
+}
+
 function HomepageHeader() {
   const [isVisible, setIsVisible] = useState(false);
+  const [starsLabel, setStarsLabel] = useState(STARS_FALLBACK_LABEL);
 
   useEffect(() => {
     setIsVisible(true);
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchStars = async () => {
+      try {
+        const response = await fetch(GITHUB_REPO_API, {
+          headers: {
+            Accept: 'application/vnd.github+json',
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(`GitHub stars fetch failed: ${response.status}`);
+        }
+
+        const data = (await response.json()) as {stargazers_count?: unknown};
+        const starCount = data.stargazers_count;
+
+        if (typeof starCount !== 'number' || !Number.isFinite(starCount)) {
+          throw new Error('GitHub stars payload missing stargazers_count');
+        }
+
+        const nextLabel = formatStarsLabel(starCount);
+
+        if (isMounted) {
+          setStarsLabel(nextLabel);
+        }
+      } catch {
+        if (isMounted) {
+          setStarsLabel(STARS_FALLBACK_LABEL);
+        }
+      }
+    };
+
+    void fetchStars();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   return (
@@ -52,7 +106,7 @@ function HomepageHeader() {
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
                   <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
                 </svg>
-                <span>1.2K+ Stars</span>
+                <span>{starsLabel}</span>
               </a>
               <a
                 href="https://github.com/grimmory-tools/grimmory"


### PR DESCRIPTION
## Summary

This PR replaces the hardcoded homepage GitHub stars label with a live value from the GitHub repo API.

**Relevant issue:** Fixes https://github.com/grimmory-tools/grimmory-docs/issues/8

## Changes

- Replaced static `1.2K+ Stars` text on homepage
- Added client-side fetch for stargazers_count from grimmory-tools/grimmory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The GitHub stars count displayed on the homepage is now dynamically fetched from the repository and updates to reflect the current count. If retrieval fails, the application gracefully falls back to a default label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->