### PR TITLE
chore: reword kobo / koreader feature card to match reality

### DIFF
--- a/src/pages/HomepageFeatures.tsx
+++ b/src/pages/HomepageFeatures.tsx
@@ -41,7 +41,7 @@ const features: FeatureItem[] = [
   {
     icon: '🔄',
     title: 'Kobo & KOReader Sync',
-    description: 'Sync reading progress and highlights across Kobo and KOReader devices seamlessly.',
+    description: 'Sync content and reading progress across Kobo and KOReader devices seamlessly.',
   },
   {
     icon: '✉️',


### PR DESCRIPTION
As it stands, the koreader / kobo descriptions are not matching how Grimmory works.  I cannot find any case where we support syncing highlights to kobo / koreader.  Instead, we support syncing of content & reading progress.

This change updates the home page to reflect that.

Fixes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the feature description text for the Kobo & KOReader Sync feature card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->