### PR TITLE
docs(gh): add pr template for docs site

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Description
+
+<!-- Required. Briefly explain what changed and why. -->
+
+## Linked Issue
+
+<!-- Required. Example: Fixes #123 -->
+
+## Changes
+
+<!-- Required. List the main changes. Use bullets if helpful. -->
+
+## Manual Testing Steps
+
+<!-- Required. List the exact steps you used to verify the docs/site behaviour and check for regressions. -->
+
+1.
+2.
+3.
+
+## Screenshots (Optional)
+
+<!-- If the UI, layout, or rendered content changed at all, attach before/after screenshots, or a short recording. If it didn't, you can delete this section. -->
+
+## Additional Context (Optional)
+
+<!-- Add anything reviewers should know that does not fit above. -->
+
+## AI Disclosure
+
+<!-- Required. Use `None` if no AI tools were used. Example: Codex - helped draft and revise docs; I reviewed all changes. -->
+
+## Checklist
+
+- [ ] This PR links and implements an accepted issue.
+- [ ] This PR is a single focused change.
+- [ ] I ran the relevant validation for this change, such as `npm run build` and/or `npm run typecheck`.
+- [ ] I have added screenshots if there were any UI changes.
+- [ ] I have disclosed any AI usage as per the organization AI Policy above.
+- [ ] I understand all of my submitted changes.


### PR DESCRIPTION
added a template that closely follows the grimmory specific repo template.

the irony is this PR for the template does not follow the template. however it will be the last one to do so :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pull request template to standardize contribution guidelines and submission requirements for improved review consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->