### PR TITLE
docs: Add details on syncing kobo rating

### DIFF
--- a/docs/integration/kobo.md
+++ b/docs/integration/kobo.md
@@ -1,6 +1,6 @@
 # Kobo Integration
 
-Kobo sync lets you send books from Grimmory to your Kobo eReader and keep reading progress in sync between both. You control what gets synced through a dedicated Kobo shelf: add a book to the shelf and it appears on your device, remove it and it disappears on the next sync. Your shelves and magic shelves carry over as Kobo collections, so the organization you've built in Grimmory follows you to the device.
+Kobo sync lets you send books from Grimmory to your Kobo eReader and sync reading activity between both systems. Reading progress sync can be bidirectional, and personal ratings set on Kobo sync back to Grimmory. You control what gets synced through a dedicated Kobo shelf: add a book to the shelf and it appears on your device, remove it and it disappears on the next sync. Your shelves and magic shelves carry over as Kobo collections, so the organization you've built in Grimmory follows you to the device.
 
 :::info[Kobo Account Required]
 Your device must be signed in to a Kobo account for this integration to function. 
@@ -163,6 +163,22 @@ When you read a book on your Kobo, the reading progress syncs back to Grimmory. 
 ![Book detail page showing Kobo Progress at 11% alongside other metadata](/img/kobo/synced-progress.jpg)
 
 Click the reset icon next to the progress to clear it in Grimmory. This does not affect the reading position on the device.
+
+### Personal Ratings
+
+When you rate a book on your Kobo and run sync, that rating is saved as your **Personal Rating** in Grimmory.
+
+How it works:
+
+1. You set a star rating on the Kobo device for a synced book.
+2. The Kobo sends that rating to Grimmory when you tap **Sync now** after setting the rating.
+3. Grimmory finds the matching book in your library and stores the value as your personal rating.
+
+- Kobo uses a 1-5 star scale.
+- Grimmory stores personal ratings on a 0-10 scale.
+- Kobo ratings are converted by doubling the value (for example, 4 stars on Kobo becomes 8 in Grimmory).
+
+This sync is currently one-way for ratings: Kobo ratings are pushed into Grimmory, but existing Grimmory personal ratings are not sent to Kobo.
 
 ---
 

--- a/docs/integration/kobo.md
+++ b/docs/integration/kobo.md
@@ -1,6 +1,6 @@
 # Kobo Integration
 
-Kobo sync lets you send books from Grimmory to your Kobo eReader and sync reading activity between both systems. Reading progress sync can be bidirectional, and personal ratings set on Kobo sync back to Grimmory. You control what gets synced through a dedicated Kobo shelf: add a book to the shelf and it appears on your device, remove it and it disappears on the next sync. Your shelves and magic shelves carry over as Kobo collections, so the organization you've built in Grimmory follows you to the device.
+Kobo sync lets you send books from Grimmory to your Kobo eReader and sync reading activity between both systems. Reading progress sync is bidirectional, and personal ratings set on Kobo sync back to Grimmory. You control what gets synced through a dedicated Kobo shelf: add a book to the shelf and it appears on your device, remove it and it disappears on the next sync. Your shelves and magic shelves carry over as Kobo collections, so the organization you've built in Grimmory follows you to the device.
 
 :::info[Kobo Account Required]
 Your device must be signed in to a Kobo account for this integration to function. 
@@ -177,8 +177,6 @@ How it works:
 - Kobo uses a 1-5 star scale.
 - Grimmory stores personal ratings on a 0-10 scale.
 - Kobo ratings are converted by doubling the value (for example, 4 stars on Kobo becomes 8 in Grimmory).
-
-This sync is currently one-way for ratings: Kobo ratings are pushed into Grimmory, but existing Grimmory personal ratings are not sent to Kobo.
 
 ---
 

--- a/docs/integration/kobo.md
+++ b/docs/integration/kobo.md
@@ -174,9 +174,7 @@ How it works:
 2. The Kobo sends that rating to Grimmory when you tap **Sync now** after setting the rating.
 3. Grimmory finds the matching book in your library and stores the value as your personal rating.
 
-- Kobo uses a 1-5 star scale.
-- Grimmory stores personal ratings on a 0-10 scale.
-- Kobo ratings are converted by doubling the value (for example, 4 stars on Kobo becomes 8 in Grimmory).
+**Note:** Kobo ratings are converted by doubling the value (for example, 4 stars on Kobo becomes 8 in Grimmory).
 
 ---
 

--- a/docs/tools/devices.md
+++ b/docs/tools/devices.md
@@ -60,7 +60,7 @@ When KOReader progress is synced to Grimmory, Grimmory automatically forwards th
 
 ## 📲 Kobo Integration
 
-Sync your Grimmory library and reading progress with your Kobo e-reader. Books on your Kobo shelf are delivered to the device, and reading progress can be synced bidirectionally.
+Sync your Grimmory library and reading activity with your Kobo e-reader. Books on your Kobo shelf are delivered to the device, reading progress can be synced bidirectionally, and Kobo personal ratings can be synced back to Grimmory.
 
 Requires the **Kobo Sync** permission.
 
@@ -124,5 +124,6 @@ KEPUB and CBX conversions take extra processing time. Large files or libraries w
 - Kobo sync creates a dedicated "Kobo" shelf automatically. Add books to this shelf (or enable auto-add) to sync them to your device.
 - Hardcover sync is triggered automatically whenever KOReader progress is updated. There is no manual sync button.
 - Reading progress from KOReader and Kobo is stored separately, so both devices can be used independently.
+- Personal ratings set on Kobo sync into Grimmory on the next Kobo sync. Kobo ratings (1-5) are converted to Grimmory personal ratings (0-10). Existing Grimmory personal ratings are not pushed to Kobo.
 - KEPUB conversion uses the [kepubify](https://github.com/pgaskin/kepubify) tool and is handled server-side.
 - All device settings changes are reflected immediately without needing to restart the server.

--- a/docs/tools/devices.md
+++ b/docs/tools/devices.md
@@ -60,8 +60,7 @@ When KOReader progress is synced to Grimmory, Grimmory automatically forwards th
 
 ## 📲 Kobo Integration
 
-Sync your Grimmory library and reading activity with your Kobo e-reader. Books on your Kobo shelf are delivered to the device, reading progress can be synced bidirectionally, and Kobo personal ratings can be synced back to Grimmory.
-
+Sync your Grimmory library and reading activity with your Kobo e-reader. Books on your Kobo shelf are delivered to your device, your reading progress syncs both ways, and your Kobo ratings update in Grimmory.
 Requires the **Kobo Sync** permission.
 
 ![Kobo Integration Configuration](/img/devices/kobo-integration.jpg)


### PR DESCRIPTION
## Description

Document how personal ratings sync from Kobo to Grimmory, including the user-facing flow, rating conversion, and sync direction.

## Linked Issue

Fixes https://github.com/grimmory-tools/grimmory-docs/issues/28

## Changes

- Updated the Kobo integration guide to explain how personal ratings move from Kobo to Grimmory.
- Added a step-by-step flow for rating sync after a user sets a rating on the Kobo device.
- Documented the rating scale conversion from Kobo’s 1-5 stars to Grimmory’s 0-10 personal rating scale.
- Clarified that rating sync is one-way for now: Kobo to Grimmory.
- Updated the opening Kobo integration description to mention personal rating sync.
- Updated the Devices page Kobo section to mention ratings syncing back to Grimmory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Kobo integration: reading progress remains bidirectional and library delivery continues.
  * Added that personal star ratings set on Kobo (1–5) are synced to Grimmory and converted to the 0–10 personal rating scale; existing Grimmory ratings are not pushed back to Kobo.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory-docs/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->