### PR TITLE
docs: Add reverse proxy X-Forwarded-Port blurb

### DIFF
--- a/docs/integration/kobo.md
+++ b/docs/integration/kobo.md
@@ -36,6 +36,8 @@ proxy_busy_buffers_size 256k;
 large_client_header_buffers 8 32k;
 ```
 
+:::info[X-Forwarded-Port] It's common in reverse proxy setups to port forward public listening ports to a different internal port. If your public listening port is different from $server_port, you must set X-Forwarded-Port to the public listening port. ie. public exposed port is 443 while nginx is listening on 8443
+
 :::info[Nginx Proxy Manager]
 The proxy headers are set automatically, but you still need to add the buffer settings manually under Advanced > Custom Nginx Configuration.
 :::

--- a/docs/integration/kobo.md
+++ b/docs/integration/kobo.md
@@ -37,6 +37,7 @@ large_client_header_buffers 8 32k;
 ```
 
 :::info[X-Forwarded-Port] It's common in reverse proxy setups to port forward public listening ports to a different internal port. If your public listening port is different from $server_port, you must set X-Forwarded-Port to the public listening port. ie. public exposed port is 443 while nginx is listening on 8443
+:::
 
 :::info[Nginx Proxy Manager]
 The proxy headers are set automatically, but you still need to add the buffer settings manually under Advanced > Custom Nginx Configuration.

--- a/docs/integration/kobo.md
+++ b/docs/integration/kobo.md
@@ -36,7 +36,9 @@ proxy_busy_buffers_size 256k;
 large_client_header_buffers 8 32k;
 ```
 
-:::info[X-Forwarded-Port] It's common in reverse proxy setups to port forward public listening ports to a different internal port. If your public listening port is different from $server_port, you must set X-Forwarded-Port to the public listening port. ie. public exposed port is 443 while nginx is listening on 8443
+:::info[X-Forwarded-Port]
+If your public listening port is different from your internal $server_port, you should set X-Forwarded-Port to the public listening port.
+For example, if your public server is available on port 443, but nginx is listening on 8443 you will need to set X-Forwarded-Port to port 443.
 :::
 
 :::info[Nginx Proxy Manager]


### PR DESCRIPTION
## Description

It's common for reverse proxy homelab setups to port forward a different public port to different internal port that the reverse proxy is listening on. Added a blurb to point out that X-Forwarded-Port may need a different setting.

## Linked Issue

https://github.com/orgs/grimmory-tools/discussions/1476

## Changes
Add info section to clarify `X-Forwarded-Port` reverse proxy header values

## AI Disclosure
AI not used

## Checklist
- [ ] This PR links and implements an accepted issue.
- [x] This PR is a single focused change.
- [ ] I ran the relevant validation for this change, such as `npm run build` and/or `npm run typecheck`.
- [ ] I have added screenshots if there were any UI changes.
- [x] I have disclosed any AI usage as per the organization AI Policy above.
- [x] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified Nginx reverse proxy guidance: added an explanatory callout advising that the X-Forwarded-Port header should reflect the public listening port when it differs from the server's internal port (e.g., when port mappings expose a different external port). No behavioral changes to integration guidance beyond this clarification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/grimmory-tools/grimmory-docs/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->