### PR TITLE
docs: add missing slugs for docs

### DIFF
--- a/src/content/docs/authentication/oidc-settings.mdx
+++ b/src/content/docs/authentication/oidc-settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OIDC Settings"
+slug: docs/authentication/oidc-settings
 sidebar:
   label: "OIDC Settings"
   order: 2

--- a/src/content/docs/authentication/overview.mdx
+++ b/src/content/docs/authentication/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Authentication Overview"
+slug: docs/authentication/overview
 sidebar:
   label: "Overview"
   order: 1

--- a/src/content/docs/integration/kobo.mdx
+++ b/src/content/docs/integration/kobo.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Kobo Integration"
+slug: docs/integration/kobo
 sidebar:
   label: "Kobo"
   order: 1

--- a/src/content/docs/integration/komga-api.mdx
+++ b/src/content/docs/integration/komga-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Komga API Integration Guide"
+slug: docs/integration/komga-api
 sidebar:
   label: "Komga API"
   order: 4


### PR DESCRIPTION
## Description

These docs are missing their slug, resulting in URLs that don't match the URL structure of other docs and 404s when accessing from Grimmory.

## Linked Issue

Fixes #45 

## Changes

Adds missing slugs for:

* authentication/oidc-settings
* authentication/overview
* integration/kobo
* integration/komga-api

## Manual Testing Steps

Ran in my local and verified the URLs were correct.

## AI Disclosure

None.

## Checklist

- [ ] This PR links and implements an accepted issue.
- [X] This PR is a single focused change.
- [X] I ran the relevant validation for this change, such as `npm run build` and/or `npm run typecheck`.
- [X] I have added screenshots if there were any UI changes.
- [X] I have disclosed any AI usage as per the organization AI Policy above.
- [X] I understand all of my submitted changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added stable URLs for authentication and integration documentation pages.
  * Improved consistency and reliability when accessing these guides directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->